### PR TITLE
support for laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "laravel/framework": "5.0 - 5.1"
+        "laravel/framework": "5.0 - 5.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Support/SteamInventoryServiceProvider.php
+++ b/src/Support/SteamInventoryServiceProvider.php
@@ -35,7 +35,7 @@ class SteamInventoryServiceProvider extends ServiceProvider
         $this->mergeConfigFrom($configPath, 'braseidon.steam-inventory');
         $this->publishes([$configPath => config_path('braseidon.steam-inventory.php')], 'config');
 
-        $this->app->bindShared('braseidon.steam-inventory', function ($app) {
+        $this->app->bind('braseidon.steam-inventory', function ($app) {
             return new SteamInventory($app->make('Illuminate\Cache\CacheManager'));
         });
 


### PR DESCRIPTION
fixing error:   Could not find package braseidon/steam-inventory-laravel at any version for your minimum-stability (stable). Check the package spelling or your minimum-stability
